### PR TITLE
Make firmware compatible with atmega platform

### DIFF
--- a/photon/platformio.ini
+++ b/photon/platformio.ini
@@ -16,7 +16,6 @@ upload_protocol = blackmagic
 ;upload_protocol = jlink
 debug_tool = blackmagic
 board_build.mcu = stm32f031k6t6
-lib_extra_dirs = ../../../lib/cpp
 build_flags = -ggdb
 debug_build_flags = -Os -ggdb2
 lib_deps = 

--- a/photon/src/PhotonFeeder.h
+++ b/photon/src/PhotonFeeder.h
@@ -1,8 +1,6 @@
 #ifndef _PHOTON_FEEDER_H
 #define _PHOTON_FEEDER_H
 
-#include <functional>
-
 #ifndef MOTOR_DEPS
     #define MOTOR_DEPS
     #include <RotaryEncoder.h>

--- a/photon/src/PhotonFeederProtocol.cpp
+++ b/photon/src/PhotonFeederProtocol.cpp
@@ -106,9 +106,7 @@ bool PhotonFeederProtocol::guardInitialized() {
         return true;
     }
 
-    response = {
-        .status = STATUS_UNINITIALIZED_FEEDER,
-    };
+    response.status = STATUS_UNINITIALIZED_FEEDER;
     memcpy(response.initializeFeeder.uuid, _uuid, UUID_LENGTH);
 
     transmitResponse(sizeof(InitializeFeederResponse));
@@ -118,9 +116,7 @@ bool PhotonFeederProtocol::guardInitialized() {
 
 
 void PhotonFeederProtocol::handleGetFeederId() {
-    response = {
-        .status = STATUS_OK
-    };
+    response.status = STATUS_OK;
     memcpy(response.getFeederId.uuid, _uuid, UUID_LENGTH);
 
     transmitResponse(sizeof(GetFeederIdResponse));
@@ -130,9 +126,7 @@ void PhotonFeederProtocol::handleInitializeFeeder() {
     // Check uuid is correct, if not return a Wrong Feeder UUID error
     bool requestedUUIDMatchesMine = memcmp(command.initializeFeeder.uuid, _uuid, UUID_LENGTH) == 0;
     if (! requestedUUIDMatchesMine) {
-        response = {
-            .status = STATUS_WRONG_FEEDER_ID,
-        };
+        response.status = STATUS_WRONG_FEEDER_ID;
         memcpy(response.initializeFeeder.uuid, _uuid, UUID_LENGTH);
 
         transmitResponse(sizeof(InitializeFeederResponse));
@@ -142,21 +136,15 @@ void PhotonFeederProtocol::handleInitializeFeeder() {
     // Mark this feeder as initialized
     _initialized = true;
 
-    response = {
-        .status = STATUS_OK,
-    };
+    response.status = STATUS_OK;
     memcpy(response.initializeFeeder.uuid, _uuid, UUID_LENGTH);
 
     transmitResponse(sizeof(InitializeFeederResponse));
 }
 
 void PhotonFeederProtocol::handleGetVersion() {
-    response = {
-        .status = STATUS_OK,
-        .protocolVersion = {
-            .version = MAX_PROTOCOL_VERSION,
-        },
-    };
+    response.status = STATUS_OK;
+    response.protocolVersion.version = MAX_PROTOCOL_VERSION;
 
     transmitResponse(sizeof(GetProtocolVersionResponse));
 }
@@ -169,12 +157,8 @@ void PhotonFeederProtocol::move(uint8_t distance, bool forward) {
     uint16_t time = _feeder->calculateExpectedFeedTime(distance, forward);
     uint16_t timeMSB = (time >> 8) | (time << 8);
 
-    response = {
-        .status = STATUS_OK,
-        .expectedTimeToFeed = {
-            .expectedFeedTime = timeMSB,
-        },
-    };
+    response.status = STATUS_OK;
+    response.expectedTimeToFeed.expectedFeedTime = timeMSB;
 
     transmitResponse(sizeof(FeedDistanceResponse));
 
@@ -217,9 +201,7 @@ void PhotonFeederProtocol::handleMoveFeedStatus() {
         break;
     }
 
-    response = {
-        .status = moveResponseStatus,
-    };
+    response.status = moveResponseStatus;
 
     transmitResponse();
 }
@@ -231,11 +213,7 @@ void PhotonFeederProtocol::handleGetFeederAddress() {
         return;
     }
 
-    response = {
-        .status = STATUS_OK,
-    };
-
-    
+    response.status = STATUS_OK;
 
     transmitResponse();
 }
@@ -247,9 +225,7 @@ void PhotonFeederProtocol::handleVendorOptions() {
 
     _feeder->vendorSpecific(command.vendorOptions.options);
 
-    response = {
-        .status = STATUS_OK,
-    };
+    response.status = STATUS_OK;
 
     transmitResponse();
 }
@@ -262,9 +238,7 @@ void PhotonFeederProtocol::handleIdentifyFeeder() {
         return;
     }
 
-    response = {
-        .status = STATUS_OK,
-    };
+    response.status = STATUS_OK;
 
     transmitResponse();
 
@@ -280,9 +254,7 @@ void PhotonFeederProtocol::handleProgramFeederFloor() {
     }
 
     uint8_t feederStatus = addressWritten ? STATUS_OK : STATUS_FAIL;
-    response = {
-        .status = feederStatus,
-    };
+    response.status = feederStatus;
 
     transmitResponse();
 }
@@ -292,10 +264,7 @@ void PhotonFeederProtocol::handleUnitializedFeedersRespond() {
         return;  // Don't respond to this command at all since we've already been initialized
     }
 
-    response = {
-        .status = STATUS_OK,
-    };
-
+    response.status = STATUS_OK;
     memcpy(response.getFeederId.uuid, _uuid, UUID_LENGTH);
 
     transmitResponse(sizeof(GetFeederIdResponse));

--- a/photon/src/PhotonNetworkLayer.cpp
+++ b/photon/src/PhotonNetworkLayer.cpp
@@ -3,8 +3,8 @@
 #include "PhotonNetworkLayer.h"
 #include "FeederFloor.h"
 #include <Arduino.h>
-#include <cstring>
-#include <cstdio>
+#include <string.h>
+#include <stdio.h>
 
 
 #ifndef NATIVE
@@ -55,7 +55,7 @@ bool PhotonNetworkLayer::getPacket(uint8_t* buffer, size_t maxBufferLength) {
     return false;
   }
 
-  size_t packet_length = std::min(_packetizer->packetLength(), maxBufferLength);
+  size_t packet_length = min(_packetizer->packetLength(), maxBufferLength);
   // iterate through all bytes in RS485 object and plop them in the buffer
   for(int i = 0; i<packet_length; i++){
     buffer[i] = (*_bus)[i];

--- a/photon/src/PhotonNetworkLayer.h
+++ b/photon/src/PhotonNetworkLayer.h
@@ -4,8 +4,8 @@
 #include "define.h"
 
 #include "FeederFloor.h"
-#include <cstddef>
-#include <cstdint>
+#include <stddef.h>
+#include <stdint.h>
 #include "PhotonPacketHandler.h"
 #include "Stream.h"
 

--- a/photon/src/PhotonPacketHandler.h
+++ b/photon/src/PhotonPacketHandler.h
@@ -1,8 +1,8 @@
 #ifndef _PHOTON_PROTOCOL_HANDLER_H
 #define _PHOTON_PROTOCOL_HANDLER_H
 
-#include <cstddef>
-#include <cstdint>
+#include <stddef.h>
+#include <stdint.h>
 
 class PhotonNetworkLayer;
 

--- a/photon/src/define.h
+++ b/photon/src/define.h
@@ -1,6 +1,9 @@
 #define DE   PA12
 #define _RE  PA11
 
+#define SERIAL_RX PA10
+#define SERIAL_TX PA9
+
 #define LED_R PA7   
 #define LED_G PA6
 #define LED_B PA4

--- a/photon/src/main.cpp
+++ b/photon/src/main.cpp
@@ -22,7 +22,7 @@ GNU GPL v3
 
 #include <RotaryEncoder.h>
 
-#endif 
+#endif
 
 #include "FeederFloor.h"
 #include "PhotonFeeder.h"
@@ -43,9 +43,11 @@ GNU GPL v3
 
 #ifdef UNIT_TEST
 StreamFake ser();
+#elif defined(SERIAL_RX) && defined(SERIAL_TX)
+HardwareSerial ser(SERIAL_RX, SERIAL_TX);
 #else
-HardwareSerial ser(PA10, PA9);
-#endif // ARDUINO
+HardwareSerial ser = Serial;
+#endif
 
 // EEPROM
 OneWire oneWire(ONE_WIRE);


### PR DESCRIPTION
This does a few things:

- replace all `#include <cstddef>` c++ style includes with c ones (`#include <stddef.h>`)
- remove a seemingly unused `#include <functional>`
- remove the deprecated `lib_extra_dirs` platformio configuration option
- replace all incomplete initializer assignments for `response`

```c
response = {
    .status = STATUS_UNINITIALIZED_FEEDER,
};
```
=>
```c
response.status = STATUS_UNINITIALIZED_FEEDER;
```