### PR TITLE
Fixed compilation error on photon-serial, fixed gearbox ratio

### DIFF
--- a/photon/platformio.ini
+++ b/photon/platformio.ini
@@ -21,7 +21,8 @@ lib_deps =
 	mike-matera/FastPID@^1.3.1
 	paulstoffregen/OneWire@^2.3.7
 	jnesselr/RS485@^0.0.9
-build_flags = -Os -ggdb2
+build_flags = -Os -ggdb2 
+              -D VERSION_STRING=\"${sysenv.VERSION_STRING}\"
 debug_build_flags = ${build_flags}
 test_ignore = test_desktop
 check_tool = cppcheck
@@ -38,13 +39,9 @@ extends = env:stm32f031k6t6
 monitor_speed = 115200
 upload_protocol = blackmagic
 debug_tool = blackmagic
-build_flags = 
-	-D VERSION_STRING=\"${sysenv.VERSION_STRING}\"
 
 [env:photon-serial]
 ; For programming feeders via the FTDI USB -> Serial tool included in shipped LumenPnPs.
 extends = env:stm32f031k6t6
 upload_protocol = serial
 upload_speed = 9600
-build_flags = 
-	-D VERSION_STRING=\"${sysenv.VERSION_STRING}\"

--- a/photon/platformio.ini
+++ b/photon/platformio.ini
@@ -46,3 +46,5 @@ build_flags =
 extends = env:stm32f031k6t6
 upload_protocol = serial
 upload_speed = 9600
+build_flags = 
+	-D VERSION_STRING=\"${sysenv.VERSION_STRING}\"

--- a/photon/src/PhotonFeeder.cpp
+++ b/photon/src/PhotonFeeder.cpp
@@ -7,16 +7,22 @@
 // --------------------
 
 // Calculating Ticks per Tenth MM
-// gearbox has ratio of 1:1030
-// encoder has 14 ticks per revolution (7 per channel)
-// one full rotation of the output shaft is 14*1030 = 14420 ticks
-// divided by 32 teeth is 450.625 ticks per tooth
-// divided by 40 tenths of a mm per tooth (4mm) is 11.265625 ticks per tenth mm
-// 8.8 microns per tick
+//
+// The "1:1030" gearbox is actually 1:1030.4 or 5:5152
+// Found by counting the actual teeth of the gears:
+// Ratio 1:  1:20
+// Ratio 2: 10:33
+// Ratio 3: 11:32
+// Ratio 4:  9:23
+// Ratio 5: 10:21
+//
+// Encoder has 14 ticks per revolution (7 per channel)
+// One full rotation of the output shaft is therefore 14*1030.4 = 14,425.6 ticks
+// divided by 32 teeth is 450.8 ticks per tooth
+// divided by 40 tenths of a mm per tooth (4mm) is 11.27 ticks per tenth mm
+// ~8.873 microns per tick
 
-// In reality, the gearbox has a slight deviation from the perfect 1:1030 gearing
-// Emperical testing brings our TICKS_PER_TENTH_MM to 11.273
-#define TICKS_PER_TENTH_MM 11.273
+#define TICKS_PER_TENTH_MM 11.27
 #define THOUSANDTHS_TICKS_PER_TENTH_MM ((uint32_t)(TICKS_PER_TENTH_MM * 1000))
 #define TENTH_MM_PER_PIP 40
 


### PR DESCRIPTION
* Compilation failed on photon-serial build due to VERSION_STRING being defined only in photon-bmp build. Fixed this by moving VERSION_STRING definition to env section of platformio.ini
* Disassembled the gearbox from one of my feeders to count the teeth and find the correct value for TICKS_PER_TENTH_MM.