### PR TITLE
Added a workaround for "ResistorGate"

### DIFF
--- a/photon/platformio.ini
+++ b/photon/platformio.ini
@@ -31,6 +31,8 @@ check_skip_packages = yes
 
 [env:stm32f031k6t6]
 board_build.mcu = stm32f031k6t6
+build_flags =
+	-D VERSION_STRING=\"${sysenv.VERSION_STRING}\"
 
 [env:photon-bmp]
 ; For programming and debugging via a BlackMagicProbe
@@ -38,8 +40,6 @@ extends = env:stm32f031k6t6
 monitor_speed = 115200
 upload_protocol = blackmagic
 debug_tool = blackmagic
-build_flags = 
-	-D VERSION_STRING=\"${sysenv.VERSION_STRING}\"
 
 [env:photon-serial]
 ; For programming feeders via the FTDI USB -> Serial tool included in shipped LumenPnPs.

--- a/photon/src/bootloader.cpp
+++ b/photon/src/bootloader.cpp
@@ -1,0 +1,64 @@
+#include "bootloader.h"
+#include "stm32f0xx_hal.h"
+#include "stm32f0xx.h"
+#include "stm32_def.h"
+
+#define SYSMEM_ADDRESS 0x1FFFEC00
+
+
+void reboot_into_bootloader() {
+    const uint32_t jump_address = *(__IO uint32_t*)(SYSMEM_ADDRESS + 4);
+
+    /* Disable peripherals */
+    HAL_RCC_DeInit();
+    HAL_DeInit();
+
+    /* Reset SysTick */
+    SysTick->CTRL = 0;
+    SysTick->LOAD = 0;
+    SysTick->VAL = 0;
+
+    /* Disable PLL */
+
+    /* Disable interrupts */
+    __disable_irq();
+
+    /* HACK
+        Workaround issue where RS485 transceiver prevents using the system bootloader via UART.
+
+        This occurs with some variants of the RS485 transceiver we use because we forgot pullup/pulldowns on the ~RE/DE
+        pins. They're left floating and sometimes that means the ~RE is enabled which prevents the UART programmer from
+        communicating with the STM32.
+
+        This works around this by configuring those pins before jumping to the bootloader and *locking* them, so that
+        they stick. This only work when jumping to the bootloader from the firmware, it won't work on a cold boot.
+    */
+     __HAL_RCC_GPIOA_CLK_ENABLE();
+    /* ~RE pin should be pulled high to disable the RS485 receiver. */
+    GPIO_InitTypeDef  RE_Init;
+    RE_Init.Pin = GPIO_PIN_11;
+    RE_Init.Mode = GPIO_MODE_OUTPUT_PP;
+    RE_Init.Pull = GPIO_PULLUP;
+    RE_Init.Speed = GPIO_SPEED_FREQ_LOW;
+    HAL_GPIO_Init(GPIOA, &RE_Init);
+    HAL_GPIO_WritePin(GPIOA, RE_Init.Pin, GPIO_PIN_SET);
+    HAL_GPIO_LockPin(GPIOA, RE_Init.Pin);
+
+    /* DE should be pulled low to disable the RS485 transmitter */
+    GPIO_InitTypeDef  DE_Init;
+    DE_Init.Pin = GPIO_PIN_12;
+    DE_Init.Mode = GPIO_MODE_OUTPUT_PP;
+    DE_Init.Pull = GPIO_PULLDOWN;
+    DE_Init.Speed = GPIO_SPEED_FREQ_LOW;
+    HAL_GPIO_Init(GPIOA, &DE_Init);
+    HAL_GPIO_WritePin(GPIOA, DE_Init.Pin, GPIO_PIN_RESET);
+    HAL_GPIO_LockPin(GPIOA, DE_Init.Pin);
+
+    /* Jump to bootloader */
+    __HAL_SYSCFG_REMAPMEMORY_SYSTEMFLASH();
+    __set_MSP(*(__IO uint32_t*)SYSMEM_ADDRESS);
+    __enable_irq();
+    ((void (*)(void)) jump_address)();
+
+    while(1);
+}

--- a/photon/src/bootloader.h
+++ b/photon/src/bootloader.h
@@ -1,0 +1,3 @@
+#pragma once
+
+void reboot_into_bootloader();

--- a/photon/src/main.cpp
+++ b/photon/src/main.cpp
@@ -22,7 +22,7 @@ MPL v2
 
 #include <RotaryEncoder.h>
 
-#endif 
+#endif
 
 #include "FeederFloor.h"
 #include "PhotonFeeder.h"
@@ -34,6 +34,8 @@ MPL v2
 #include <rs485/filters/filter_by_value.h>
 #include <rs485/protocols/photon.h>
 #include <rs485/packetizer.h>
+
+#include "bootloader.h"
 
 #define BAUD_RATE 57600
 
@@ -59,7 +61,7 @@ Packetizer packetizer(bus, photon_protocol);
 FilterByValue addressFilter(0);
 
 // Encoder
-RotaryEncoder encoder(DRIVE_ENC_A, DRIVE_ENC_B, RotaryEncoder::LatchMode::TWO03); 
+RotaryEncoder encoder(DRIVE_ENC_A, DRIVE_ENC_B, RotaryEncoder::LatchMode::TWO03);
 
 // Flags
 bool drive_mode = false;
@@ -197,7 +199,7 @@ void bottomLongPress(){
 
 void bothLongPress(){
   //both are pressed, switching if we are driving tape or film
-  
+
   if(drive_mode){
     feeder->set_rgb(false, false, true);
     drive_mode = false;
@@ -216,8 +218,20 @@ void bothLongPress(){
     //do nothing while waiting for debounce
     if((timerStart + 2000 < millis()) && !alreadyFlashed){
       feeder->set_rgb(false, false, false);
-      showVersion(); 
+      showVersion();
       alreadyFlashed = true;
+    }
+
+    // if held for a really long time, reboot into the bootloader
+    if((timerStart + 4000 < millis())){
+      for (int n = 0; n < 10; n++) {
+        feeder->set_rgb(!(n % 2), false, n % 2);
+        delay(100);
+      }
+    }
+    if((timerStart + 6000 < millis())){
+      feeder->set_rgb(true, false, true);
+      reboot_into_bootloader();
     }
   }
 
@@ -244,7 +258,7 @@ inline void checkButtons() {
       }
       // if bottom short press
       else{
-        bottomShortPress(); 
+        bottomShortPress();
       }
     }
     // Checking top button
@@ -264,7 +278,7 @@ inline void checkButtons() {
       // if top short press
       else{
         topShortPress();
-      }  
+      }
     }
   }
   else{


### PR DESCRIPTION
An issue exists where the RS485 transceiver will sometimes prevent communicating with the bootloader over UART. This is ultimately due to the ~RE and DE pins being left floating, which for *some* boards will cause the ~RE pin to bias high enough to enable the transceiver while the bootloader is active. Since the bootloader and RS485 use the same UART, this causes the RS485 transceiver to interfere, preventing flashing over UART. A hardware fix is needed to completely address this bug, but this change adds an additional software-based workaround for existing boards.

If the user holds down the forward/reverse buttons for about ~5 seconds, the firmware will configure the ~RE and DE pins appropriately, lock their configuration, and then manually jump into the bootloader. Entering the bootloader this way allows us enough control over the state of the pins to disable the transceiver and prevent it from interfering.

Note that if the programming process is interrupted or fails, the device can not be recovered without a SWD programmer. Without this workaround existing boards that exhibit this issue can only be programmed over SWD anyway, so that takes a little bit of sting out of this caveat.