### PR TITLE
Set minimum ststm32/frameworks versions

### DIFF
--- a/photon/platformio.ini
+++ b/photon/platformio.ini
@@ -12,7 +12,8 @@
 default_envs = photon-bmp
 
 [env]
-platform = ststm32
+platform = ststm32@>=19.7.0
+platform_packages = framework-arduinoststm32 @ >=4.21200.0
 board = photon_v2
 framework = arduino
 


### PR DESCRIPTION
The `u2` branch uses a custom PlatformIO board definition with variants. The current project implementation requires Arduino Core v2.0.0+ to support that variant handling, but platformio.ini does not set any minimum version on platform/platform_packages, which bundle the Arduino Core. 

Users with older versions of the core installed encounter an error:
```
| #include "variant.h"
| ^~~~~~~~~~~
compilation terminated.
*** [.pio\build\photon-bmp\FrameworkArduino\WInterrupts.cpp.o] Error 1
```

This PR proposes the following minimums to ensure support:

```
platform = ststm32@>=19.7.0
platform_packages = framework-arduinoststm32 @ >=4.21200.0
```
Closes Issue #15 